### PR TITLE
fix: prevent featured image flash during article view transition

### DIFF
--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -1,5 +1,4 @@
 ---
-import { Picture } from "astro:assets";
 import { getCollection } from "astro:content";
 import { HIDE_CHROME, SITE_URL } from "astro:env/client";
 import { PAGES_ROUTES } from "@const/index";
@@ -10,6 +9,7 @@ import ReadingProgress from "@modules/article/components/readingProgress/Reading
 import RepublishedBanner from "@modules/article/components/republishedBanner/RepublishedBanner.astro";
 import TableOfContents from "@modules/article/components/tableOfContents/TableOfContents.astro";
 import BaseLayout from "@modules/core/components/baseLayout/BaseLayout.astro";
+import BlurImage from "@modules/core/components/blurImage/BlurImage.astro";
 import Breadcrumbs from "@modules/core/components/breadcrumbs/Breadcrumbs.astro";
 import RelatedArticles from "@modules/core/components/relatedArticles/RelatedArticles.astro";
 import type { InferGetStaticPropsType } from "astro";
@@ -55,21 +55,19 @@ const scopes = article.data.tableOfContents.map((_, index) => `--section-${index
   {
       article.data.featuredImage && (
           <section class="article__featured-image-wrapper">
-              <Picture
+              <BlurImage
                   src={`https:${article.data.featuredImage.url}`}
                   width={article.data.featuredImage.details.width}
                   height={article.data.featuredImage.details.height}
-                  formats={['avif', 'webp']}
-                  fallbackFormat="jpeg"
                   widths={[640, 960, 1280, 1920]}
                   sizes="100vw"
                   alt={article.data.title}
+                  placeholder={article.data.featuredImage.placeholder}
                   loading="eager"
                   fetchpriority="high"
                   decoding="async"
                   class="article__featured-image"
-                  pictureAttributes={{ style: 'display:block;width:100%' }}
-                  transition:name=`featured-image-${article.data.slug}`
+                  transitionName={`featured-image-${article.data.slug}`}
               />
           </section>
       )

--- a/src/pages/articles/_article.css
+++ b/src/pages/articles/_article.css
@@ -10,8 +10,10 @@ html.--is-article body {
 }
 
 .article__featured-image {
+	display: block;
 	max-height: 50vh;
 	object-fit: cover;
+	width: 100%;
 }
 
 .article__heading {


### PR DESCRIPTION
## Problem

Navigating to an article (from an article card or the *Related articles* section) sometimes showed a white flash on the featured image during the view transition: the morph target was blank and the image only appeared once the transition had finished. On subsequent visits — with the image cached — the transition was smooth.

Root cause: the destination featured image was a fresh, large `<Picture>` resource (different srcset/size than the card thumbnail). View Transitions snapshot the destination element when the animation starts, before that image has decoded, so the snapshot was empty and the white page background showed through.

## Fix

Render the featured image through `BlurImage` instead of `Picture`. `BlurImage` paints the LQIP placeholder (an inline base64 data URI already generated in the articles loader) as the element background, so the transition morphs into the blurred placeholder — which is available synchronously — instead of white. The sharp image then decodes in on top. This also unifies the featured image with the cards and the rest of the remote images, which already use `BlurImage`.

## Notes

- Responsive `widths` / `sizes` are kept (resolution switching still matters for the LCP hero).
- Explicit `formats={['avif','webp']}` / `fallbackFormat` are dropped: on the Cloudflare image service a format-less request resolves to `format=auto`, so avif/webp are still served via content negotiation — no format regression.
- The LQIP placeholder is a ~24px data URI excluded from LCP candidacy, and the hero image keeps `loading="eager"` + `fetchpriority="high"`, so LCP is unaffected.
