### PR TITLE
ci: normalize the deploy workflow against contribKit, and fix the dependency cache

### DIFF
--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -1,5 +1,5 @@
 name: 'Prepare Environment'
-description: 'Sets up Node.js and pnpm environment'
+description: 'Sets up Node.js and pnpm environment, then installs dependencies'
 runs:
   using: "composite"
   steps:
@@ -17,10 +17,8 @@ runs:
     - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version-file: .nvmrc
+        cache: pnpm
 
-    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: '**/node_modules'
-        key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -1,9 +1,9 @@
-name: 'Prepare Environment'
-description: 'Sets up Node.js and pnpm environment, then installs dependencies'
+name: Prepare environment
+description: Sets up pnpm, Node.js and dependencies
 runs:
   using: "composite"
   steps:
-    - name: Validate .nvmrc exists
+    - name: Verify .nvmrc is present
       shell: bash
       run: |
         if [ ! -f .nvmrc ]; then
@@ -11,7 +11,7 @@ runs:
           exit 1
         fi
 
-    - name: Install pnpm
+    - name: Setup pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
     - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -77,10 +77,14 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/prepare-env
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
       - name: Build
-        run: pnpm build
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 15
+          shell: bash
+          command: pnpm build
       - name: Deploy to Cloudflare Workers
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
@@ -101,15 +105,17 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
           INPUTS_WORKER_NAME: ${{ inputs.worker_name }}
+          INPUTS_WRANGLER_ENV: ${{ inputs.wrangler_env }}
         with:
           timeout_minutes: 2
           max_attempts: 3
           retry_wait_seconds: 15
           shell: bash
           command: |
-            TARGET_FLAG=""
             if [ -n "${INPUTS_WORKER_NAME}" ]; then
               TARGET_FLAG="--name ${INPUTS_WORKER_NAME}"
+            else
+              TARGET_FLAG="--env ${INPUTS_WRANGLER_ENV}"
             fi
             node -e "
             const required = ['RESEND_API_KEY','CONTENTFUL_SPACE_ID','CONTENTFUL_DELIVERY_TOKEN','CONTENTFUL_PREVIEW_TOKEN','CONTENTFUL_SIGNIN_TOKEN','ASTRO_DB_REMOTE_URL','ASTRO_DB_APP_TOKEN'];

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,11 +178,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/prepare-env
-      - name: Install Playwright Browsers
+      - name: Install Playwright browsers
         run: pnpm playwright install --with-deps
-      - name: Run E2E Tests
+      - name: Run E2E tests
         run: pnpm test:e2e
-      - name: Upload Artifact
+      - name: Upload artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/prepare-env
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
       - name: Lint
         run: pnpm lint:all
       - name: Generate types
@@ -83,8 +81,6 @@ jobs:
           token: ${{ secrets.PAT }}
           persist-credentials: false
       - uses: ./.github/actions/prepare-env
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
       - name: Generate types
         run: pnpm run sync
       - name: Semantic Release
@@ -182,8 +178,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/prepare-env
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
       - name: Install Playwright Browsers
         run: pnpm playwright install --with-deps
       - name: Run E2E Tests

--- a/.github/workflows/cleanup-development.yml
+++ b/.github/workflows/cleanup-development.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/prepare-env
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
       - name: Delete preview Worker
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,7 +8,7 @@ jobs:
         name: Dependency Review
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout Repository
+            - name: Checkout
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                 persist-credentials: false

--- a/.github/workflows/end-2-end-tests.yml
+++ b/.github/workflows/end-2-end-tests.yml
@@ -19,8 +19,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/prepare-env
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/end-2-end-tests.yml
+++ b/.github/workflows/end-2-end-tests.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - name: Checkout Repository
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -25,18 +25,18 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - name: Install Playwright Browsers
+      - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm playwright install --with-deps chromium webkit
       - name: Install Playwright OS dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm playwright install-deps chromium webkit
-      - name: Run E2E Tests
+      - name: Run E2E tests
         run: ${E2E_COMMAND}
         env:
           CI: ${{ env.CI }}
           E2E_URL: ${{ env.E2E_URL }}
-      - name: Upload Artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-name: Security Analysis with zizmor 🌈
+name: Security Analysis with zizmor
 on:
   push:
     branches: ["main"]
@@ -7,7 +7,7 @@ on:
 permissions: {}
 jobs:
   zizmor:
-    name: Run zizmor 🌈
+    name: Run zizmor
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -16,5 +16,5 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - name: Run zizmor 🌈
+      - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false


### PR DESCRIPTION
Brings this repo in line with contribKit's reusable deploy, and fixes two things that turned up while comparing the three.

## Retry on Build

`Build` joins the deploy and the secret bulk behind `nick-fields/retry`, on contribKit's 10m/3-attempt budget. `astro build` pulls content from Contentful, which makes it the step here most exposed to somebody else's uptime — and the only one of the three deploy pipelines where the build was left unguarded.

## prepare-env had a different contract from the other two

contribKit and forever-pto both install dependencies inside their composite action. This one only set up the toolchain, so all **six** call sites had to follow it with their own `pnpm install --frozen-lockfile`. Same name, same shape, different contract — easy to get wrong the next time a workflow is added.

The install moves into the action and the six duplicates come out. No behaviour change, one less thing to remember.

## The node_modules cache was the wrong shape for pnpm

```diff
-    - uses: actions/cache@... 
-      with:
-        path: '**/node_modules'
+        cache: pnpm
```

pnpm's store is content-addressable and `node_modules` is a tree of symlinks into it. Caching that tree directly is fragile and misses the store entirely, which is the part actually worth caching. `cache: pnpm` on `setup-node` caches the store — what contribKit and forever-pto already do.

## Set Worker secrets was leaning on an ambient variable

```diff
-            TARGET_FLAG=""
             if [ -n "${INPUTS_WORKER_NAME}" ]; then
               TARGET_FLAG="--name ${INPUTS_WORKER_NAME}"
+            else
+              TARGET_FLAG="--env ${INPUTS_WRANGLER_ENV}"
             fi
```

On production `worker_name` is empty, so `wrangler secret bulk` ran with no target flag at all. It resolved to production correctly — but only via the job-level `CLOUDFLARE_ENV`. Remove that line in some future refactor and production secrets would go silently to the top-level Worker with nothing failing loudly. forever-pto already had this fallback; now both do.

## Scope

Deliberately **not** changed: the `CLOUDFLARE_ENV` mechanism for selecting the wrangler environment. It is correct, it is verified working in production, and swapping it for forever-pto's explicit `--env` purely for cosmetic parity would be churn with real downside. The `--env` above is additive — it only fills the case that previously had no flag at all.
