### PR TITLE
ci: stop deleting the preview Worker while E2E is still using it

### DIFF
--- a/.github/workflows/cleanup-development.yml
+++ b/.github/workflows/cleanup-development.yml
@@ -7,6 +7,13 @@ on:
 permissions:
   contents: read
 
+# Queues behind ci.yml, whose `E2E (preview)` job drives this same preview
+# Worker. The group is its `${{ github.workflow }}-${{ github.ref }}`; renaming
+# that workflow silently stops the wait.
+concurrency:
+  group: CI-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     name: Delete preview Worker


### PR DESCRIPTION
## The race

`cleanup-development.yml` fires on `pull_request: closed`, and closing a pull request does not cancel the run already in flight. `ci.yml`'s **E2E (preview)** job `needs: [deploy-development]` and drives `pr-<n>-biancafiore-development` **over the network**, so the delete races it — every remaining spec then runs against a Worker that no longer exists and fails for a reason unrelated to the code.

Renovate is how it happens: it auto-merges once the *required* checks pass, and `E2E (preview)` is not one of them.

## The fix

A queue, not a wait loop. The cleanup declares `ci.yml`'s own concurrency group with `cancel-in-progress: false`:

```yaml
concurrency:
  group: CI-${{ github.ref }}
  cancel-in-progress: false
```

`ci.yml`'s group is `${{ github.workflow }}-${{ github.ref }}`, and a `pull_request` event carries the same `refs/pull/<number>/merge` whichever activity type fired it — so the two strings match and GitHub holds the cleanup pending until the CI run completes. A pending run occupies no runner, so this costs nothing. No polling, no `actions: read`, no third-party action.

## What to watch

**The coupling is by workflow name.** Renaming `name: CI` silently unqueues the cleanup and the race comes back. The file carries a comment saying so.

Note `end-2-end-tests.yml` is not involved — it is `workflow_dispatch` only and targets the production/self-hosted URL, never the per-PR Worker. The job that races is the one inside `ci.yml`.

## Not fixed here

The root cause is that `E2E (preview)` is not a required status check, which is why Renovate merges ahead of it. That is a branch-protection setting rather than a file in the repo — worth doing, and it would stop the premature merge itself rather than just protecting the Worker from it.

Found while auditing the same defect across all three Cloudflare Worker repos; `contribKit` and `forever-pto` have it too and are getting the same change.