### PR TITLE
feat(home): fade testimonials in as they snap via scroll-state

### DIFF
--- a/src/ui/modules/home/components/testimonialsSlider/testimonials-slider.css
+++ b/src/ui/modules/home/components/testimonialsSlider/testimonials-slider.css
@@ -68,6 +68,31 @@
 	line-height: var(--leading);
 }
 
+@supports (container-type: scroll-state) {
+	.testimonials__slider .testimonial {
+		opacity: 0.15;
+		transition:
+			opacity 0.4s ease,
+			translate 0.4s ease;
+		translate: 0 var(--space-2xs);
+	}
+
+	@container scroll-state(snapped: inline) {
+		.testimonials__slider .testimonial {
+			opacity: 1;
+			translate: 0 0;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.testimonials__slider .testimonial {
+			opacity: 1;
+			transition: none;
+			translate: 0 0;
+		}
+	}
+}
+
 .testimonials__nav {
 	align-items: center;
 	display: flex;


### PR DESCRIPTION
## Description

The slider shell has declared `container-type: scroll-state` on every `.slider__slide` for a while, but nothing consumed it. This wires up the missing half: the testimonials slider now reacts to the snapped slide in pure CSS, with no script tracking which slide is active.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update

## Related Issue

None.

## Changes Made

- Testimonials rest dimmed (`opacity: 0.15`) and slightly lowered (`--space-2xs`); the slide snapped in the inline axis rises to full opacity via `@container scroll-state(snapped: inline)`, so swipes cross-fade as the browser settles on a snap target.
- The whole treatment sits behind `@supports (container-type: scroll-state)`: engines without scroll-state queries (Safari, Firefox) keep every slide fully visible, exactly as before. This is the inverse of the `scrollTop` pattern, which can afford hidden-by-default.
- `prefers-reduced-motion: reduce` pins everything static at full opacity, following the `reveal.css` convention.

Deliberately out of scope: the nav dashes stay in JS (scroll-state queries only style descendants of the snapped container, and the dashes are siblings of the track), and the article sliders get no treatment (with several cards per view and `scroll-snap-align: start`, only the edge-aligned card counts as snapped — highlighting it against equally visible neighbours would read as a bug).

## Testing

- [x] Existing unit tests pass (`pnpm test:ut`)
- [ ] Added new tests for changes
- [ ] Manually tested in browser
- [ ] Build passes (`pnpm build`)

## Screenshots (if applicable)

N/A — the effect only shows mid-swipe.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm lint:all` and `pnpm format:all` pass)
- [x] I have performed a self-review of my own code
- [x] My change carries no inline comments — rationale lives in this PR, the commit messages, or the folder's guide
- [x] I updated any `CLAUDE.md`, `CONTEXT.md` or ADR my change affects, in this same PR
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

CSS-only change; no doc claims an invariant about slider visuals, so no guide needed updating (`pnpm test:docs` passes, 98/98). The build box is unchecked only because the sandbox lacks Contentful credentials for the prerendered pages — CI builds with real secrets and will verify it.

---

## GIF (mandatory)

<div align="center">

<!-- Add a funny or cute GIF here -->

_Thanks for contributing!_ ✨

</div>